### PR TITLE
Allow syntax supported by default browserify configuration

### DIFF
--- a/src/spec-parser.js
+++ b/src/spec-parser.js
@@ -1,6 +1,11 @@
 const falafel = require('falafel')
 const debug = require('debug')('cypress-select-tests')
 
+const acornOptions = {
+  ecmaVersion: 9,
+  sourceType: 'module'
+}
+
 const isTestBlock = name => node => {
   return (
     node.type === 'CallExpression' &&
@@ -92,7 +97,7 @@ const findTests = source => {
   }
 
   // ignore source output for now
-  falafel(source, onNode)
+  falafel(source, acornOptions, onNode)
 
   return foundTestNames
 }
@@ -131,7 +136,7 @@ const skipTests = (source, leaveTests) => {
     // }
   }
 
-  const output = falafel(source, onNode)
+  const output = falafel(source, acornOptions, onNode)
   return output.toString()
 }
 


### PR DESCRIPTION
Currently this plugin is not yet on par with the default options of browserify processor, which allows syntax like import/export, object rest spread, etc...

This PR will set options for acorn to remedy that, so users won't have to rewrite their tests when adding this plugin as their preprocessor.