### PR TITLE
Preserve default browserify configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@ const itify = require('./itify')
 const onFilePreprocessor = (config, pickTests) => {
   const options = {
     browserifyOptions: {
-      extensions: ['.js'],
-      transform: itify(config, pickTests)
+      transform: [
+          ...browserify.defaultOptions.browserifyOptions.transform,
+          itify(config, pickTests)
+      ]
     }
   }
 


### PR DESCRIPTION
We should extend instead of override the default browserify configuration, which already supports coffee, jsx, es6 syntax, etc... 